### PR TITLE
PB-662 use image attribute

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,4 @@
+image: "sorchaabel/ruby-pipeline-example:1.0"
 steps:
   - name: ":rspec:"
     command: "bundle install && bundle exec rspec --color specs"


### PR DESCRIPTION
Use new step `image` attribute to use docker hub image
For complete e2e it's using an image i posted to dockerhub
I'll circle back in a few days and update this to use a buildkite official image. 